### PR TITLE
Show mint limits for on-chain deposits

### DIFF
--- a/src/components/CreateInvoiceDialog.vue
+++ b/src/components/CreateInvoiceDialog.vue
@@ -75,6 +75,15 @@
           </div>
         </div>
 
+        <div v-if="isOnchain" class="row justify-center q-px-lg q-mb-sm">
+          <div class="col-12 col-sm-11 col-md-8" style="max-width: 600px">
+            <OnchainDepositLimits
+              :mint-url="activeMintUrl"
+              :unit="activeUnit"
+            />
+          </div>
+        </div>
+
         <!-- Amount display -->
         <div class="col column items-center justify-center q-px-lg amount-area">
           <transition name="fade" mode="out-in">
@@ -239,6 +248,7 @@ import VueQrcode from "@chenfengyuan/vue-qrcode";
 import ChooseMint from "components/ChooseMint.vue";
 import NumericKeyboard from "components/NumericKeyboard.vue";
 import AmountInputComponent from "components/AmountInputComponent.vue";
+import OnchainDepositLimits from "components/OnchainDepositLimits.vue";
 import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
 import { useMintsStore } from "src/stores/mints";
@@ -258,6 +268,7 @@ export default defineComponent({
     ChooseMint,
     NumericKeyboard,
     AmountInputComponent,
+    OnchainDepositLimits,
     VueQrcode,
   },
   props: {},

--- a/src/components/InvoiceDetailDialog.vue
+++ b/src/components/InvoiceDetailDialog.vue
@@ -88,6 +88,18 @@
               </div>
             </div>
 
+            <div v-if="isOnchain" class="row justify-center q-mb-md">
+              <div
+                class="col-12 col-sm-11 col-md-8 q-px-md"
+                style="max-width: 600px"
+              >
+                <OnchainDepositLimits
+                  :mint-url="invoiceData.mint"
+                  :unit="invoiceData.unit"
+                />
+              </div>
+            </div>
+
             <q-card-section class="q-pa-sm">
               <div
                 v-if="invoiceData?.mintQuote"
@@ -165,6 +177,7 @@ import { useUiStore } from "../stores/ui";
 import { useWorkersStore } from "../stores/workers";
 import MeltQuoteInformation from "./MeltQuoteInformation.vue";
 import MintQuoteInformation from "./MintQuoteInformation.vue";
+import OnchainDepositLimits from "components/OnchainDepositLimits.vue";
 import { PaymentMethod } from "src/stores/walletTypes";
 // type hint for global mixin
 declare const windowMixin: any;
@@ -176,6 +189,7 @@ export default defineComponent({
     VueQrcode,
     MeltQuoteInformation,
     MintQuoteInformation,
+    OnchainDepositLimits,
   },
   props: {},
   data: function () {

--- a/src/components/OnchainDepositLimits.vue
+++ b/src/components/OnchainDepositLimits.vue
@@ -1,0 +1,66 @@
+<template>
+  <q-banner v-if="limits" rounded class="deposit-limits-warning bg-warning">
+    <template v-slot:avatar>
+      <q-icon name="warning" color="dark" />
+    </template>
+    <div class="text-dark text-weight-medium">On-chain deposit limits</div>
+    <div class="text-dark text-body2">
+      {{ limitMessage }} Deposits outside this range may not be credited and
+      could be lost.
+    </div>
+  </q-banner>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { mapState } from "pinia";
+import { useMintsStore } from "src/stores/mints";
+import { PaymentMethod } from "src/stores/walletTypes";
+import { mintPaymentMethodLimits } from "src/js/mint-payment-methods";
+
+declare const windowMixin: any;
+
+export default defineComponent({
+  name: "OnchainDepositLimits",
+  mixins: [windowMixin],
+  props: {
+    mintUrl: {
+      type: String,
+      required: true,
+    },
+    unit: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    ...mapState(useMintsStore, ["mints"]),
+    limits() {
+      const mint = this.mints.find((entry) => entry.url === this.mintUrl);
+      return mintPaymentMethodLimits(
+        mint,
+        PaymentMethod.Onchain,
+        "mint",
+        this.unit
+      );
+    },
+    limitMessage(): string {
+      if (!this.limits) return "";
+      const min = this.limits.minAmount;
+      const max = this.limits.maxAmount;
+      if (min != null && max != null) {
+        return `Send between ${this.formatLimit(min)} and ${this.formatLimit(
+          max
+        )}.`;
+      }
+      if (min != null) return `Send at least ${this.formatLimit(min)}.`;
+      return `Send no more than ${this.formatLimit(max as number)}.`;
+    },
+  },
+  methods: {
+    formatLimit(amount: number): string {
+      return (this as any).formatCurrency(amount, this.unit, true);
+    },
+  },
+});
+</script>

--- a/src/js/__tests__/mint-payment-methods.test.js
+++ b/src/js/__tests__/mint-payment-methods.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   firstMintSupportingPaymentMethods,
+  mintPaymentMethodLimits,
   mintSupportsPaymentMethod,
 } from "src/js/mint-payment-methods";
 import { PaymentMethod } from "src/stores/walletTypes";
@@ -88,5 +89,46 @@ describe("mint payment method helpers", () => {
         "usd"
       )
     ).toBe(true);
+  });
+
+  it("returns limits for the matching payment method and unit", () => {
+    const mint = {
+      ...onchainOnlyMint,
+      info: {
+        nuts: {
+          4: {
+            methods: [
+              {
+                method: "onchain",
+                unit: "sat",
+                min_amount: 10_000,
+                max_amount: 1_000_000,
+              },
+              {
+                method: "onchain",
+                unit: "usd",
+                min_amount: 1,
+                max_amount: 100,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(
+      mintPaymentMethodLimits(mint, PaymentMethod.Onchain, "mint", "sat")
+    ).toEqual({ minAmount: 10_000, maxAmount: 1_000_000 });
+  });
+
+  it("returns null when a mint does not advertise deposit limits", () => {
+    expect(
+      mintPaymentMethodLimits(
+        onchainOnlyMint,
+        PaymentMethod.Onchain,
+        "mint",
+        "sat"
+      )
+    ).toBeNull();
   });
 });

--- a/src/js/mint-payment-methods.ts
+++ b/src/js/mint-payment-methods.ts
@@ -8,6 +8,43 @@ function nut4Config(info?: GetInfoResponse) {
 
 type MintOperation = "mint" | "melt";
 
+export type PaymentMethodLimits = {
+  minAmount: number | null;
+  maxAmount: number | null;
+};
+
+function amountLikeToNumber(value: any): number | null {
+  if (value == null) return null;
+  if (typeof value?.toNumber === "function") return value.toNumber();
+  const amount = Number(value);
+  return Number.isFinite(amount) ? amount : null;
+}
+
+export function mintPaymentMethodLimits(
+  mint: StoredMint | undefined,
+  method: PaymentMethod,
+  operation: MintOperation = "mint",
+  unit?: string
+): PaymentMethodLimits | null {
+  if (!mint) return null;
+  const nut =
+    operation === "melt"
+      ? mint.info?.nuts?.[5] || mint.info?.nuts?.["5"]
+      : mint.info?.nuts?.[4] || mint.info?.nuts?.["4"];
+  const advertisedMethod = nut?.methods?.find(
+    (entry: { method: string; unit?: string; disabled?: boolean }) =>
+      entry.disabled !== true &&
+      entry.method === method &&
+      (!unit || !entry.unit || entry.unit === unit)
+  );
+  if (!advertisedMethod) return null;
+
+  const minAmount = amountLikeToNumber(advertisedMethod.min_amount);
+  const maxAmount = amountLikeToNumber(advertisedMethod.max_amount);
+  if (minAmount == null && maxAmount == null) return null;
+  return { minAmount, maxAmount };
+}
+
 export function mintSupportsPaymentMethod(
   mint: StoredMint,
   method: PaymentMethod,


### PR DESCRIPTION
## Summary
- read on-chain deposit limits from NUT-04 metadata for the selected mint and unit
- warn before creating or reusing an address that out-of-range deposits may not be credited and could be lost
- keep the warning visible beside the generated deposit address
- support minimum-only, maximum-only, and bounded ranges without inventing absent limits

## Verification
- npm run lint
- npm run test:ci (73 tests)
- npm run build